### PR TITLE
Add intent router functionality to chatbot

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 0.15.22 - Intent Router
+
+* Chatbot - The chatbot now has simple heuristics (based on LLM queries) to determine the users intent and to route to the built-in functions to ground the response. This includes internet search functions `/news`, `/stock`, `/weather` and `/search`.
+* To activate set environmental variable `INTENT_ROUTER=true` or use the prompt command `/intent on`.
+
+<img width="800" alt="image" src="https://github.com/user-attachments/assets/564faa56-e5a9-4042-8635-dff3fcbbdb74" />
+
 ## 0.15.21 - Internet Search
 
 * Chatbot - The `/search` command has been added to allow the chatbot to search the internet to help answer your prompt. By default, the first 5 most relevant internet search results are added to the context.

--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -43,6 +43,7 @@ docker run \
     -p 5000:5000 \
     -e PORT=5000 \
     -e OPENAI_API_BASE="http://localhost:8000/v1" \
+    -e INTENT_ROUTER=false \
     -e TZ="America/Los_Angeles" \
     -v $PWD/.tinyllm:/app/.tinyllm \
     --name chatbot \
@@ -151,6 +152,7 @@ Some RAG (Retrieval Augmented Generation) features including:
 /think filter [on|off]                  # Have chatbot filter out <think></think> content
 /model [LLM_name]                       # Display or select LLM model to use (dialogue popup)
 /search [opt:number] [prompt]           # Search the web to help answer the prompt
+/intent [on|off]                        # Activate intent router to automatically run above functions
 ```
 
 See the [rag](../rag/) for more details about RAG.
@@ -202,9 +204,17 @@ docker run \
 
 The [settings.yml](./litellm/searxng/settings.yml) file needs to be edited to allow the json format. 
 
-The chatbot looks for the environmental variable `SEARXNG` to set the URL of the search service, otherwise it uses http://localhost:8080.
+The chatbot looks for the environmental variable `SEARXNG` to set the URL of the search service, otherwise it uses http://localhost:8080. You can activate it by using the prompt command like this: `/search What is the cost of gas in Texas?`
 
 <img width="800" alt="image" src="https://github.com/user-attachments/assets/8ee65216-6b11-4590-bf19-695e5b6e9a63" />
+
+#### Intent Router
+
+The chatbot now has the ability to read prompts and determine if a function call would help provide a grounded answer. 
+
+It can be activated by setting the `INTENT_ROUTER=true` environmental variable or using the prompt command `/intent on`.  It will use things like /search to find current data on things that tend to change frequently (e.g. cost of eggs). It will also use /weather, /stock and /news. The heuristics it is using is based on LLM calls so the performance will vary based on the LLM you are using. It was tuned for use with the Llama-3.2-11B-Vision model.
+
+<img width="800" alt="image" src="https://github.com/user-attachments/assets/422a7c13-ec6f-43bb-a959-e37d0bb709ec" />
 
 ## Document Manager (Weaviate)
 

--- a/chatbot/litellm/compose.yaml
+++ b/chatbot/litellm/compose.yaml
@@ -91,6 +91,7 @@ services:
       - LITELLM_PROXY=http://litellm-proxy:4000/v1
       - LITELLM_KEY=sk-3-laws-safe
       - SEARXNG=http://searxng:8080
+      - INTENT_ROUTER=false
       - LLM_MODEL=local-pixtral
       - TZ=America/Los_Angeles
     volumes:

--- a/chatbot/server.py
+++ b/chatbot/server.py
@@ -1657,7 +1657,7 @@ async def process_search(session_id, prompt, context):
         if "\n" in search_topic:
             search_topic = search_topic.split("\n")[0]
         if search_topic:
-            await handle_search_command(session_id, f"/search {search_topic}")
+            await handle_search_command(session_id, f"/search {search_topic}", original_prompt=prompt)
             return True
         else:
             return False
@@ -1676,7 +1676,7 @@ async def handle_intent_command(session_id, p):
         await sio.emit('update', {'update': '[Usage: /intent on|off] - Enable or disable the intent engine. Currently: ' + current_state, 'voice': 'user'}, room=session_id)
 
 
-async def handle_search_command(session_id, p):
+async def handle_search_command(session_id, p, original_prompt=""):
     # Check to see if SEARXNG is enabled
     if not SEARXNG:
         await sio.emit('update', {'update': '[Search Engine Disabled - Check Config]', 'voice': 'user'}, room=session_id)
@@ -1701,7 +1701,8 @@ async def handle_search_command(session_id, p):
         await sio.emit('update', {'update': '[Usage: /search {opt:number} {query} or /search on|off] - Search the internet. State: ' + current_state, 'voice': 'user'}, room=session_id)
         return
     await sio.emit('update', {'update': '%s [Searching...]' % p, 'voice': 'user'}, room=session_id)
-    prompt = "Based on the above, " + prompt
+    if original_prompt:
+        prompt = original_prompt
     context_str = await search_web(session_id, prompt, max_results) or "[Error searching the web]"
     client[session_id]["visible"] = False
     client[session_id]["remember"] = True

--- a/chatbot/version.py
+++ b/chatbot/version.py
@@ -1,1 +1,1 @@
-VERSION = "v0.15.21"
+VERSION = "v0.15.22"


### PR DESCRIPTION
## 0.15.22 - Intent Router

* Chatbot - The chatbot now has simple heuristics (based on LLM queries) to determine the users intent and to route to the built-in functions to ground the response. This includes internet search functions `/news`, `/stock`, `/weather` and `/search`.
* To activate set environmental variable `INTENT_ROUTER=true` or use the prompt command `/intent on`.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/564faa56-e5a9-4042-8635-dff3fcbbdb74" />
